### PR TITLE
changed return type from Cint to Int, for some funcs

### DIFF
--- a/src/aleinterface.jl
+++ b/src/aleinterface.jl
@@ -191,7 +191,7 @@ Applies an action to the game and returns the reward. It is the user's
 responsibility to check if the game has ended and reset when neccessary -
 this function will keep pushing buttons on the game over screen.
 """
-act(ale::ALEPtr, action::Integer) =
+act(ale::ALEPtr, action::Integer)::Int =
     ccall((:act, libale_c), Cint, (ALEPtr, Cint), ale, Cint(action))
 
 """
@@ -218,7 +218,7 @@ Returns the vector of the legal set of actions needed the play the game. Not to 
 See also: [`getMinimalActionSet`](@ref)
 """
 function getLegalActionSet(ale::ALEPtr)
-    actions = Cint[]
+    actions = Int[]
     _getLegalActionSet!(ale, actions)
     actions
 end
@@ -247,7 +247,7 @@ Returns the set of actions that actually affect the game. Not to be confused wit
 See also: [`getLegalActionSet`](@ref)
 """
 function getMinimalActionSet(ale::ALEPtr)
-    actions = Cint[]
+    actions = Int[]
     _getMinimalActionSet!(ale, actions)
     actions
 end
@@ -313,9 +313,9 @@ function getRAM(ale::ALEPtr)
 end
 
 # Screen function utilities
-getScreenWidth(ale::ALEPtr) =
+getScreenWidth(ale::ALEPtr)::Int =
     ccall((:getScreenWidth, libale_c), Cint, (ALEPtr,), ale)
-getScreenHeight(ale::ALEPtr) =
+getScreenHeight(ale::ALEPtr)::Int =
     ccall((:getScreenHeight, libale_c), Cint, (ALEPtr,), ale)
 getScreen!(ale::ALEPtr, screen_data::Vector{Cuchar}) =
     ccall((:getScreen, libale_c), Cvoid, (ALEPtr, Ptr{Cuchar}), ale, screen_data)

--- a/src/aleinterface.jl
+++ b/src/aleinterface.jl
@@ -218,9 +218,9 @@ Returns the vector of the legal set of actions needed the play the game. Not to 
 See also: [`getMinimalActionSet`](@ref)
 """
 function getLegalActionSet(ale::ALEPtr)
-    actions = Int[]
+    actions = Cint[]
     _getLegalActionSet!(ale, actions)
-    actions
+    Int.(actions)
 end
 
 function _getLegalActionSet!(ale::ALEPtr, actions::Vector{Cint})
@@ -247,9 +247,9 @@ Returns the set of actions that actually affect the game. Not to be confused wit
 See also: [`getLegalActionSet`](@ref)
 """
 function getMinimalActionSet(ale::ALEPtr)
-    actions = Int[]
+    actions = Cint[]
     _getMinimalActionSet!(ale, actions)
-    actions
+    Int.(actions)
 end
 
 function _getMinimalActionSet!(ale::ALEPtr, actions::Vector{Cint})

--- a/src/aleinterface.jl
+++ b/src/aleinterface.jl
@@ -236,7 +236,7 @@ Returns the size of the legal action set. Not to be confused with `getMinimalAct
 
 See also: [`getLegalActionSize`](@ref)
 """
-getLegalActionSize(ale::ALEPtr) =
+getLegalActionSize(ale::ALEPtr)::Int =
     ccall((:getLegalActionSize, libale_c), Cint, (ALEPtr,), ale)
 
 """
@@ -265,7 +265,7 @@ Returns the size of the minimal action set required to play the game. Not to be 
 
 See also: [`getLegalActionSize`](@ref)
 """
-getMinimalActionSize(ale::ALEPtr) =
+getMinimalActionSize(ale::ALEPtr)::Int =
     ccall((:getMinimalActionSize, libale_c), Cint, (ALEPtr,), ale)
 
 """


### PR DESCRIPTION
In this PR, I have changed the return type of functions `getScreenWidth`, `getScreenHeight`, `act`, `getLegalActionSize`, `getMinimalActionSize` from `Int32` to the more commonly used `Int` and similar changes for the eltype of `getMinimalActionSet` and `getLegalActionSet`. These functions serve as part of the interface to the ArcadeLearningEnvironment and their return values are usually directly plugged into other functions. Those functions then error out because their arguments expect `Int` values, whereas `Int32` values are passed.